### PR TITLE
Bulk discount delete

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -14,6 +14,13 @@ class BulkDiscountsController < ApplicationController
     redirect_to merchant_bulk_discounts_path(@merchant)
   end
 
+  def destroy
+    @merchant = Merchant.find(params[:merchant_id])
+    @bulk_discount = BulkDiscount.find(params[:id])
+    @bulk_discount.destroy!
+    redirect_to merchant_bulk_discounts_path(@merchant.id) 
+  end
+
   private
   def discount_params
     params.permit(:percentage_discount, :quantity_threshold)

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -6,6 +6,7 @@
       <li>Save <%= discount.percentage_discount %>% when you purchase <%= discount.quantity_threshold %> of the same item.</li>
         <ul>
           <li><%= link_to "Learn more about this offer!", merchant_bulk_discount_path(@merchant.id, discount.id) %></li>
+          <li><%= link_to "Delete This Offer", merchant_bulk_discount_path(@merchant.id, discount.id), method: :delete %></li>
         </ul>
     </ul>
   </div>

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -110,5 +110,33 @@ RSpec.describe "merchants bulk index page", type: :feature do
     end
   end
 
+  it 'each bulk discount has a link to delete that discount. when the merchant
+  clicks this link, it redirects back to the bulk discount index page and that
+  discount is not longer listed' do
+    visit merchant_bulk_discounts_path(@crystal_moon)
+
+    within "#merchant-discount#{@bulk_discount_a.id}" do
+      expect(page).to have_link("Delete This Offer")
+    end
+
+    within "#merchant-discount#{@bulk_discount_b.id}" do
+      expect(page).to have_link("Delete This Offer")
+    end
+
+    within "#merchant-discount#{@bulk_discount_b.id}" do
+      click_link "Delete This Offer"
+    end
+
+    expect(current_path).to eq(merchant_bulk_discounts_path(@crystal_moon))
+    expect(page).to_not have_css("#merchant-discount#{@bulk_discount_b.id}")
+    expect(page).to have_css("#merchant-discount#{@bulk_discount_a.id}")
+    
+    within "#merchant-discount#{@bulk_discount_a.id}" do
+      click_link "Delete This Offer"
+    end
+
+    expect(current_path).to eq(merchant_bulk_discounts_path(@crystal_moon))
+    expect(page).to have_css("#merchant-discount#{@bulk_discount_a.id}")
+  end
 end
 

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe "merchants bulk index page", type: :feature do
     end
 
     expect(current_path).to eq(merchant_bulk_discounts_path(@crystal_moon))
-    expect(page).to have_css("#merchant-discount#{@bulk_discount_a.id}")
+    expect(page).to_not have_css("#merchant-discount#{@bulk_discount_a.id}")
   end
 end
 


### PR DESCRIPTION
- adds a button to the merchants bulk discount index with the option to delete a discount
- when the merchant clicks the link to delete a discount, they are redirected back to their bulk discount index, and they not longer see that bulk discount on their page. 